### PR TITLE
Exclude virtualenv from Flake8 linting. Again.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length=120
 application_import_names=bot
+exclude=.venv


### PR DESCRIPTION
No idea why this was removed.